### PR TITLE
Add user match statistics for statistical visualisation

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -163,14 +163,18 @@ def profile(username):
         models.FriendRequest.to_user_id == user.id
     )) is not None 
 
-    return render_template("user.html", user=user, friend_requests=friend_requests, is_friend=is_friend)
+    matches = models.Matches.query.filter_by(user_id=user.id).all()
+    total_games = len(matches)
+    wins = sum(1 for m in matches if m.result.lower() == 'win')
+    losses = sum(1 for m in matches if m.result.lower() == 'loss')
+    draws = sum(1 for m in matches if m.result.lower() == 'draw')
+    win_pct = round((wins / total_games) * 100, 2) if total_games > 0 else 0
+
+    return render_template("user.html",user=user,is_friend=is_friend,friend_requests=friend_requests,matches=matches,
+    total_games=total_games,wins=wins,losses=losses,draws=draws,win_pct=win_pct
+)
     
     
-    
-    
-    
-    
-    return render_template("user.html", user=user)
 
 @application.route('/edit_profile', methods=["GET", "POST"])
 @login_required

--- a/app/templates/user.html
+++ b/app/templates/user.html
@@ -47,16 +47,27 @@ Tournament Manager - {{ user.username }}
                 {% endif %}
             </div>
         </div>
+
         {% if user.private == 0 or user.username == current_user.username %}
             <div>
                 <h1>Recent Tournaments</h1>
                 {% if tournaments %}
                     {% for tournament in tournaments %}
-                    <!-- Display tournaments associated with user -->
+                        <!-- Display tournaments associated with user -->
                     {% endfor %}
                 {% else %}
                     <h3 class="text-white">This user has not competed in any tournaments yet.</h3>
                 {% endif %}
+            </div>
+
+            <!-- Match Statistics Section -->
+            <div class="bg-gray-800 p-6 rounded-lg shadow-md mt-6 text-white">
+                <h2 class="text-xl font-bold mb-4">Match Statistics</h2>
+                <p>Total Games Played: {{ total_games }}</p>
+                <p>Wins: {{ wins }}</p>
+                <p>Losses: {{ losses }}</p>
+                <p>Draws: {{ draws }}</p>
+                <p>Win Percentage: {{ win_pct }}%</p>
             </div>
         {% else %}
             <h1>This user has their profile set to private!</h1>


### PR DESCRIPTION
This PR adds a basic statistical analysis feature on each individual user's profile page. It displays the total number of games played, wins, losses, draws, and win percentage based on the recorded match results for that user.

The key changed that were added was I modified routes.py to:
-Query all matches played by the user.
-Calculate `total_games, wins, losses, draws, and win_pct`
-Pass these values to the template.

Modified user.html to:
- Display these stats neatly under a "Match Statistics" section if the user's profile is not private.

The purpose of this was to let users get insight into their performance.
Some possible improvements for the future could be showing statistics for each specific game (example showing wins,losses etc. for Chess seperately). 